### PR TITLE
Send SIGTERM to Supervisor on container stop

### DIFF
--- a/client/entrypoint.sh
+++ b/client/entrypoint.sh
@@ -17,4 +17,12 @@ fi
 #  find /opt/hydrus/ -not -path "/opt/hydrus/db/*" -exec chown hydrus:hydrus "{}" \;
 #fi
 
-supervisord -c /etc/supervisord.conf
+stop() {
+  pkill supervisord
+  sleep 1
+}
+
+trap "stop" SIGTERM
+
+supervisord -c /etc/supervisord.conf &
+wait $!


### PR DESCRIPTION
Supervisor currently doesn't receive the `SIGTERM` signal when the container stops; this commit addresses this.

Background: Supervisor sends `SIGTERM` to all managed processes when it itself is told to stop. Since Hydrus itself also handles `SIGTERM` (and `SIGINT`) correctly now (see [here](https://github.com/hydrusnetwork/hydrus/blob/b6e0948fda39b6b3daab20dcf8dffe17b3d44485/include/ClientController.py#L383-L396)), making it so Supervisor itself receives a `SIGTERM` allows us to shut Hydrus down cleanly on container stop.